### PR TITLE
Update Shadowrocket.conf

### DIFF
--- a/Shadowrocket.conf
+++ b/Shadowrocket.conf
@@ -208,4 +208,4 @@ localhost = 127.0.0.1
 ^https?:\/\/(www.)?(g|google)\.(cn|com\.hk) https://www.google.com 302
 
 [MITM]
-hostname = *.google.com.cn,*.google.com.hk
+hostname = *.google.cn,*.google.com.cn,*.google.com.hk


### PR DESCRIPTION
MITM中添加*.google.cn使iOS设备默认谷歌搜索引擎跳过google.com.hk跳转。